### PR TITLE
Support multiline commands for events

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ python main.py example.yaml
 
 ## YAML-File
 
-The YAML-File needs two keys, `setup` and `events` on the base level. 
+The YAML-File needs two keys, `setup` and `events` on the base level.
 ```yaml
 setup:
     # docker-compose setup
@@ -22,7 +22,7 @@ events:
     # processed by event engine
 ```
 
-The setup part will be piped directly to docker-compose. 
+The setup part will be piped directly to docker-compose.
 This means, the whole part of container setup is managed by docker-compose.
 You can use each version of the docker-compose-file and all supported features.
 
@@ -44,14 +44,17 @@ Each event can be directly identified with the key and has the following structu
 event1:
     dependOn: <list-of-events>
     seconds: <amount-of-seconds>
-    command: <some-command>
+    commands:
+      - command1
+      - command2
+      - ....
     do:
         <map of actions>
 ```
 
-The first three keys describes when the `do`-block should be executed. 
+The first three keys describes when the `do`-block should be executed.
 The order of these conditions is as shown above.
-This means for example that after the events this event1 dependsOn have returned, the program waited a few seconds and the command has succesfully been executed the do-part of this event will be executed.
+This means for example that after the events this event1 dependsOn have returned, the program waited a few seconds and the commands have succesfully been executed the do-part of this event will be executed.
 
 #### dependOn
 `dependOn` takes a list of other events (identified with their keys).
@@ -73,14 +76,16 @@ seconds: 5
 ```
 This means the execution waits 5 seconds.
 
-#### command
-It can execute any command and if this command returns `1`, the `do`-block will be executed.
+#### commands
+It can execute any list of commands and if this command returns `1`, the `do`-block will be executed.
 
 Example:
 ```yaml
-command: "ping -c 1 192.168.1.2"
+command:
+  - ping -c 1 192.168.1.2
+  - ls
 ```
-This would test if the computer with the IP-address `192.168.1.2` is reachable and execute the `do`-block (if there is an connection) once the command returned `1`.
+This would test if the computer with the IP-address `192.168.1.2` is reachable and execute the `do`-block (if there is an connection) once the command returned `1`. Afterwards it executes ls and executes the `do`-block if ls fails.
 
 #### do
 The `do`-block will be executed when all conditions (see above) were processed.
@@ -139,7 +144,7 @@ The value `container` are the identifiers of the containers, specified in the se
 The action will create a new network and add these containers to the network.
 The sorted list of the containers is the key of the network (not the name).
 
-The value of `internal` can be `True` or `False`. 
+The value of `internal` can be `True` or `False`.
 It maps to the [internal flag](https://docs.docker.com/engine/reference/commandline/network_create/#network-internal-mode) of docker.
 
 The `mode` can be any of `row`, `ring` or `cluster`.
@@ -195,7 +200,7 @@ restartContainer: ["Node3"]
 This example starts `Node1`, stops `Node2` and restarts `Node3`.
 
 #### delay, duplicate, corrupt and loss
-These actions use the linux network emulator `netem`. 
+These actions use the linux network emulator `netem`.
 Make sure that your container support this network emulator when using this command.
 Have a look at the [documentation](http://man7.org/linux/man-pages/man8/tc-netem.8.html) for details.
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 * Python 2.7 installed
 * PyYaml installed (see: [documentation](http://pyyaml.org/wiki/PyYAML))
-* Docker with Docker-composed installed
+* Docker with Docker-compose installed
 
 ## Example-Run:
 
 ```
-python main.py example.yaml
+python main.py examples/example-containers.yaml
 ```
 
 ## YAML-File
@@ -81,12 +81,22 @@ It can execute any list of commands and if this command returns `1`, the `do`-bl
 
 Example:
 ```yaml
-command:
+commands:
   - ping -c 1 192.168.1.2
   - ls
 ```
-This would test if the computer with the IP-address `192.168.1.2` is reachable and execute the `do`-block (if there is an connection) once the command returned `1`. Afterwards it executes ls and executes the `do`-block if ls fails.
+This would test if the computer with the IP-address `192.168.1.2` is reachable and execute the `do`-block (if there is a connection) once the command returned `1`. Afterwards it executes ls and executes the `do`-block if ls succeeds.
 
+#### command (outdated)
+
+It can execute any command and if this command returns `1`, the `do`-block will be executed.
+
+Example:
+```yaml
+command: ping -c 1 192.168.1.2
+```
+
+This would test if the computer with the IP-adress `192.168.1.2` is reachable and execute the `do`-block (if there is a connection) once the command returned `1`.
 #### do
 The `do`-block will be executed when all conditions (see above) were processed.
 Its a map from the key of an action to the values of these actions.

--- a/eventWorker.py
+++ b/eventWorker.py
@@ -24,8 +24,14 @@ class eventWorker (threading.Thread):
             print "sleep for " + str(self.eventObject["seconds"]) + " seconds"
             time.sleep(int(self.eventObject["seconds"]))
 
+        if "command" in self.eventObject:
+            print "execute command: " + self.eventObject["command"]
+            exitCode = call(self.eventObject["command"], shell=True)
+            if exitCode != 0:
+                print "command exited with exit code " + str(exitCode) + ". Abort."
+                return exitCode
+
         if "commands" in self.eventObject:
-            print "execute commands: " + str(self.eventObject["commands"])
             for command in self.eventObject["commands"]:
                 print "execute command: " + command
                 exitCode = call(command, shell=True)

--- a/eventWorker.py
+++ b/eventWorker.py
@@ -24,12 +24,14 @@ class eventWorker (threading.Thread):
             print "sleep for " + str(self.eventObject["seconds"]) + " seconds"
             time.sleep(int(self.eventObject["seconds"]))
 
-        if "command" in self.eventObject:
-            print "execute command: " + self.eventObject["command"]
-            exitCode = call(self.eventObject["command"], shell=True)
-            if exitCode != 0:
-                print "commend exited with exit code " + str(exitCode) + ". Abort."
-                return exitCode
+        if "commands" in self.eventObject:
+            print "execute commands: " + str(self.eventObject["commands"])
+            for command in self.eventObject["commands"]:
+                print "execute command: " + command
+                exitCode = call(command, shell=True)
+                if exitCode != 0:
+                    print "command exited with exit code " + str(exitCode) + ". Abort."
+                    return exitCode
 
         if "do" in self.eventObject:
             doObject = self.eventObject["do"]


### PR DESCRIPTION
Change "command" of the event object to "commands" and accept a collection, which is then executed in sequence. Might be useful for setting up things (like a DB) in a more convenient way (similar to GitLab CI yml structure).